### PR TITLE
Alpha - Tokenization - Define header interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Once the second roadmap stage has been completed, an alpha 0.2.0 release will be
 ### 4.1 Worklist
 To reach the current goal, the following steps will be taken, in the order shown below:
 
-- [ ] Define the shasm_block interface in a header
+- [x] Define the shasm_block interface in a header
 - [ ] Define the test_block testing module
 - [ ] Implement the buffer functions of the block reader
 - [ ] Implement the token function of the block reader

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -1,0 +1,72 @@
+/*
+ * shasm_block.c
+ * 
+ * Implementation of shasm_block.h
+ * 
+ * See the header for further information.
+ */
+#include "shasm_block.h"
+
+/* @@TODO: finish the implementation */
+
+/* @@TODO: finish the local functions given below */
+
+/*
+ * Set the input line number associated with the block that has just
+ * been read into the buffer.
+ * 
+ * The provided line number must be in range one up to LONG_MAX, with
+ * LONG_MAX being a special value indicating that the line number has
+ * overflowed.
+ * 
+ * If the block reader is in an error state (see shasm_block_status),
+ * then the line number of the most recent block will be frozen at
+ * LONG_MAX, and calls to this function will be ignored.  The line
+ * number of the error that stopped the block reader is handled
+ * separately.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader
+ * 
+ *   line - the line number to set
+ */
+static void shasm_block_setLine(SHASM_BLOCK *pb, long line);
+
+/*
+ * Clear the block reader's internal buffer to an empty string.
+ * 
+ * This does not reset the error status of the block reader (see
+ * shasm_block_status).
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to clear
+ */
+static void shasm_block_clear(SHASM_BLOCK *pb);
+
+/*
+ * Append an unsigned byte value (0-255) to the end of the block
+ * reader's internal buffer.
+ * 
+ * This might cause the buffer to be reallocated, so pointers returned
+ * by shasm_block_ptr become invalid after calling this function.
+ * 
+ * This function will fail if the buffer already has SHASM_BLOCK_MAXSTR
+ * bytes in it.  In this case, the internal buffer will be cleared and
+ * the block reader will be set to error SHASM_ERR_HUGEBLOCK.
+ * 
+ * If this function is called when the block reader is already in an
+ * error state, the function fails and does nothing further.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to append a byte to
+ * 
+ *   c - the unsigned byte value to append (0-255)
+ * 
+ * Return:
+ * 
+ *   non-zero if successful, zero if failure
+ */
+static int shasm_block_addByte(SHASM_BLOCK *pb, int c);

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -1,0 +1,223 @@
+#ifndef SHASM_BLOCK_H_INCLUDED
+#define SHASM_BLOCK_H_INCLUDED
+
+/*
+ * shasm_block.h
+ * 
+ * Block reader module of libshasm.
+ * 
+ * This module converts a filtered stream of characters from shasm_input
+ * into strings of zero to 65,535 bytes.
+ * 
+ * For multithreaded applications, this module is safe to use, provided
+ * that each SHASM_BLOCK instance is only used from one thread at a 
+ * time, and provided that the raw input callback used by the provided
+ * SHASM_IFLSTATE is safe to call from multiple threads (but only from
+ * one thread at a time).
+ */
+
+#include "shasm_error.h"
+#include "shasm_input.h"
+
+/*
+ * The maximum number of data bytes that can be stored in the block
+ * reader buffer, as a signed long constant.
+ * 
+ * This does not include a terminating null.
+ */
+#define SHASM_BLOCK_MAXSTR (65535L)
+
+/*
+ * Structure prototype for the block reader state structure.
+ * 
+ * The actual structure is defined in the implementation.
+ */
+struct SHASM_BLOCK_TAG;
+typedef struct SHASM_BLOCK_TAG SHASM_BLOCK;
+
+/*
+ * Allocate a block reader linked to the provided input filter chain.
+ * 
+ * The provided input filter chain must not be freed while a block
+ * reader is linked to it, or undefined behavior occurs.  The block
+ * reader will not free the filter chain, so the client must free the
+ * filter chain after the block reader has been freed.
+ * 
+ * The returned block reader should eventually be freed with
+ * shasm_block_free.
+ * 
+ * Parameters:
+ * 
+ *   ps - the input filter chain to link to this block reader
+ * 
+ * Return:
+ * 
+ *   a new block reader
+ */
+SHASM_BLOCK *shasm_block_alloc(SHASM_IFLSTATE *ps);
+
+/*
+ * Free a block reader.
+ * 
+ * If NULL is passed, this call is ignored.
+ * 
+ * Note that the input filter chain linked to the block reader is not
+ * freed by this function.  The client must free that separately after
+ * calling this function to free the block reader.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to free, or NULL
+ */
+void shasm_block_free(SHASM_BLOCK *pb);
+
+/*
+ * Determine the status of a block reader.
+ * 
+ * This returns one of the codes defined in shasm_error.h
+ * 
+ * If the return value is SHASM_OKAY, then it means the block reader is
+ * functional and not in an error state.  pLine is ignored in this case.
+ * 
+ * If the return value is something else, it means the block reader is
+ * in an error state.  The return value is an error code from
+ * shasm_error.  If pLine is not NULL, the input line number the error
+ * occurred at will be saved to *pLine, or LONG_MAX will be written if
+ * the line count overflowed.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to query
+ * 
+ *   pLine - pointer to variable to receive the line number if there is
+ *   an error, or NULL
+ * 
+ * Return:
+ * 
+ *   SHASM_OKAY if block reader is functional, or else an error code
+ *   from shasm_error
+ */
+int shasm_block_status(SHASM_BLOCK *pb, long *pLine);
+
+/*
+ * The number of bytes of data stored in the block reader buffer.
+ * 
+ * This is initially zero.  This will always return zero if the block
+ * reader is in an error state (see shasm_block_status).
+ * 
+ * After a successful block reading function, this will be the number of
+ * bytes in the result string that has been read into the buffer.  The
+ * range is zero up to and including SHASM_BLOCK_MAXSTR (65,535).  This
+ * does not include a terminating null character.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to query
+ * 
+ * Return:
+ * 
+ *   the number of bytes present in the string buffer
+ */
+long shasm_block_count(SHASM_BLOCK *pb);
+
+/*
+ * Get a pointer to the block reader's data buffer.
+ * 
+ * If the client is expecting a null-terminated string pointer,
+ * null_term should be set to non-zero.  The function will return NULL
+ * in this case if the string data includes null bytes (and is therefore
+ * impossible to safely null terminate).
+ * 
+ * If the client can handle data that includes null bytes, then set
+ * null_term to zero and use shasm_block_count to determine how many
+ * bytes of data are stored in the buffer.
+ * 
+ * The provided pointer is to the internal buffer of the string reader.
+ * The client should not modify it or try to free it.  The pointer is
+ * valid until another reading function is called or the block reader is
+ * freed (whichever occurs first).  The client should call this function
+ * again after each call to the reading function, in case the block
+ * reader has reallocated the buffer.
+ * 
+ * If the length of the data is zero, then the returned pointer will
+ * point to a string consisting solely of a null termination byte.
+ * 
+ * After each successful block read function, the resulting string will
+ * be stored in this buffer.  If the block reader is in an error state
+ * (see shasm_block_status), then an empty string will be stored in the
+ * buffer.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to query
+ * 
+ *   null_term - non-zero if the client expects a null-terminated
+ *   string, zero if the client can handle strings including null bytes
+ * 
+ * Return:
+ * 
+ *   a pointer to the block reader's internal buffer, or NULL if the
+ *   null_term flag was set but the string data includes null bytes
+ */
+unsigned char *shasm_block_ptr(SHASM_BLOCK *pb, int null_term);
+
+/*
+ * Return the input line number that the block that was just read began
+ * at.
+ * 
+ * If no blocks have been read yet, this function will return a value of
+ * one.  This function will return LONG_MAX if the block reader is in
+ * an error state (see shasm_block_status).
+ * 
+ * Otherwise, this function returns the line number of the start of the
+ * most recent block, or LONG_MAX if the line number overflowed.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to query
+ * 
+ * Return:
+ * 
+ *   the line number or LONG_MAX
+ */
+long shasm_block_line(SHASM_BLOCK *pb);
+
+/*
+ * Clear the block reader's internal buffer to an empty string.
+ * 
+ * This does not reset the error status of the block reader (see
+ * shasm_block_status).
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to clear
+ */
+void shasm_block_clear(SHASM_BLOCK *pb);
+
+/*
+ * Append an unsigned byte value (0-255) to the end of the block
+ * reader's internal buffer.
+ * 
+ * This might cause the buffer to be reallocated, so pointers returned
+ * by shasm_block_ptr become invalid after calling this function.
+ * 
+ * This function will fail if the buffer already has SHASM_BLOCK_MAXSTR
+ * bytes in it.  In this case, the internal buffer will be cleared and
+ * the block reader will be set to error SHASM_ERR_HUGEBLOCK.
+ * 
+ * If this function is called when the block reader is already in an
+ * error state, the function fails and does nothing further.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to append a byte to
+ * 
+ *   c - the unsigned byte value to append (0-255)
+ * 
+ * Return:
+ * 
+ *   non-zero if successful, zero if failure
+ */
+int shasm_block_addByte(SHASM_BLOCK *pb, int c);
+
+#endif

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -231,7 +231,16 @@ long shasm_block_line(SHASM_BLOCK *pb);
  * (0x21-0x7e) and not HT SP or LF is encountered, SHASM_ERR_TOKENCHAR,
  * except if this character occurs within a comment, in which case it is
  * skipped over.
- 
+ *
+ * Parameters:
+ * 
+ *   pb - the block reader
+ * 
+ *   ps - the input filter chain to read from
+ * 
+ * Return:
+ * 
+ *   non-zero if successful, zero if error
  */
 int shasm_block_token(SHASM_BLOCK *pb, SHASM_IFLSTATE *ps);
 

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -182,42 +182,4 @@ unsigned char *shasm_block_ptr(SHASM_BLOCK *pb, int null_term);
  */
 long shasm_block_line(SHASM_BLOCK *pb);
 
-/*
- * Clear the block reader's internal buffer to an empty string.
- * 
- * This does not reset the error status of the block reader (see
- * shasm_block_status).
- * 
- * Parameters:
- * 
- *   pb - the block reader to clear
- */
-void shasm_block_clear(SHASM_BLOCK *pb);
-
-/*
- * Append an unsigned byte value (0-255) to the end of the block
- * reader's internal buffer.
- * 
- * This might cause the buffer to be reallocated, so pointers returned
- * by shasm_block_ptr become invalid after calling this function.
- * 
- * This function will fail if the buffer already has SHASM_BLOCK_MAXSTR
- * bytes in it.  In this case, the internal buffer will be cleared and
- * the block reader will be set to error SHASM_ERR_HUGEBLOCK.
- * 
- * If this function is called when the block reader is already in an
- * error state, the function fails and does nothing further.
- * 
- * Parameters:
- * 
- *   pb - the block reader to append a byte to
- * 
- *   c - the unsigned byte value to append (0-255)
- * 
- * Return:
- * 
- *   non-zero if successful, zero if failure
- */
-int shasm_block_addByte(SHASM_BLOCK *pb, int c);
-
 #endif

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -13,12 +13,32 @@
 #define SHASM_OKAY (0)
 
 /*
+ * The raw input reader returned an I/O error.
+ */
+#define SHASM_ERR_IO (1)
+
+/*
+ * The raw input reader returned an End Of File (EOF) condition.
+ * 
+ * Since Shastina files must end with a "|;" token, it is always an
+ * error to encounter an EOF while parsing the file.
+ */
+#define SHASM_ERR_EOF (2)
+
+/*
  * An attempt was made to append more than 65,535 bytes to a block
  * reader's internal buffer.
  * 
  * This indicates that a token or string data that decodes to a string
  * longer than 65,535 bytes was encountered in the input file.
  */
-#define SHASM_ERR_HUGEBLOCK (1)
+#define SHASM_ERR_HUGEBLOCK (3)
+
+/*
+ * A character outside printing US-ASCII range appeared within a token.
+ * 
+ * The only characters allowed within tokens are in the range 0x21-0x7e.
+ */
+#define SHASM_ERR_TOKENCHAR (4)
 
 #endif

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -1,0 +1,24 @@
+#ifndef SHASM_ERROR_H_INCLUDED
+#define SHASM_ERROR_H_INCLUDED
+
+/*
+ * shasm_error.h
+ * 
+ * Error code definitions for libshasm.
+ */
+
+/*
+ * Status code that means there is no error.
+ */
+#define SHASM_OKAY (0)
+
+/*
+ * An attempt was made to append more than 65,535 bytes to a block
+ * reader's internal buffer.
+ * 
+ * This indicates that a token or string data that decodes to a string
+ * longer than 65,535 bytes was encountered in the input file.
+ */
+#define SHASM_ERR_HUGEBLOCK (1)
+
+#endif


### PR DESCRIPTION
Defined the basic specification of the shasm_block interface in a header.  Also got a start on some of the low-level buffer function specifications, which are in the implementation file.  (They were originally part of the public interface, but then moved to local functions.)