### PR TITLE
Alpha - Tokenization - Buffer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ The line unghosting filter discards whitespace sequences consisting of SP and HT
 
 With the caveat that the tab unghosting filter may change the alignment of text in certain circumstances, the tab and line unghosting filter sequence should have the same effect as the original unghosting filter, while being much easier to implement.
 
+### 2.2 Maximum block and string length
+
+Section 5.5 and a few other sections of draft 3V:C4-5 of the Shastina Specification establish a limit of 65,535 bytes as the maximum length of decoded string literals.  libshasm works according to this specification, except when the size_t is less than 32-bit or the implementation constant SHASM_BLOCK_MAXBUFFER has been adjusted in the block reader implementation.  In these cases, there is an implementation limit on strings that is lower than 65,535 bytes.
+
+If size_t is less than 32-bit but SHASM_BLOCK_MAXBUFFER has not been adjusted, then this lower implementation limit on string length is 65,534 bytes, which is just one byte shy of the specification.  However, if SHASM_BLOCK_MAXBUFFER is adjusted down, this limit may be significantly lower.  libshasm distinguishes between the specification limit and the implementation limit by raising SHASM_ERR_HUGEBLOCK if the specification limit has been exceeded or SHASM_ERR_LARGEBLOCK if the implementation-specific lower limit has been exceeded -- see the documentation of those errors for further information.
+
+The divergence, therefore, is that implementations of Shastina do not necessarily support the full 65,535-byte string length.  An updated draft of the specification should set a minimum implementation limit and say that the actual limit is somewhere between this minimum implementation limit and 65,535.  The documentation within the libshasm sources can then be clarified.
+
 ## 3. Roadmap
 The current development roadmap is as follows.  Section references are to the Shastina language specification, currently on draft 3V:C4-5.
 
@@ -68,7 +76,7 @@ To reach the current goal, the following steps will be taken, in the order shown
 
 - [x] Define the shasm_block interface in a header
 - [x] Define the test_block testing module
-- [ ] Implement the buffer functions of the block reader
+- [x] Implement the buffer functions of the block reader
 - [ ] Implement the token function of the block reader
 
 The block interface and testing module will be limited to just the token function for now.  The string data functions will be added in subsequent roadmap steps.

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -10,10 +10,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* @@TODO: finish the implementation */
-/* @@TODO: spec divergence to change maximum string length so it can
- * be supported on 16-bit platforms */
-
 /*
  * The initial capacity of the block buffer in bytes, as a signed long
  * constant.
@@ -458,4 +454,12 @@ long shasm_block_line(SHASM_BLOCK *pb) {
   
   /* Return result */
   return result;
+}
+
+/*
+ * shasm_block_token function.
+ */
+int shasm_block_token(SHASM_BLOCK *pb, SHASM_IFLSTATE *ps) {
+  /* @@TODO: replace placeholder */
+  return 0;
 }

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -6,10 +6,207 @@
  * See the header for further information.
  */
 #include "shasm_block.h"
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* @@TODO: finish the implementation */
+/* @@TODO: spec divergence to change maximum string length so it can
+ * be supported on 16-bit platforms */
+
+/*
+ * The initial capacity of the block buffer in bytes, as a signed long
+ * constant.
+ * 
+ * This includes space for the terminating null character.
+ * 
+ * This value must be at least two, and not be greater than
+ * SHASM_BLOCK_MAXBUFFER.
+ * 
+ * This module will run this value through shasm_block_adjcap to limit
+ * it to 65535 on platforms where size_t is less than 32-bit.
+ */
+#define SHASM_BLOCK_MINBUFFER (32L)
+
+/*
+ * The maximum capacity of the block buffer in bytes, as a signed long
+ * constant.
+ * 
+ * This includes space for the terminating null character.  Blocks may
+ * be no longer than one less than this value in length.  Since the
+ * maximum block size supported by Shastina is 65,535 bytes, this value
+ * is one greater than that.
+ * 
+ * This value must not be less than SHASM_BLOCK_MINBUFFER.  It must also
+ * be less than half of LONG_MAX, so that doubling the capacity never
+ * results in overflow.
+ * 
+ * This module will run this value through shasm_block_adjcap to limit
+ * it to 65535 on platforms where size_t is less than 32-bit.  In this
+ * case, the maximum block size supported by libshasm will be 65,534
+ * bytes, which is one byte shy of the specification.
+ * 
+ * On platforms with a 16-bit size_t, it may be a good idea to adjust
+ * this value down to avoid memory allocation faults.  But note that
+ * adjusting this value down will diverge from the specification by not
+ * supporting the full 65,535-byte size of strings.
+ */
+#define SHASM_BLOCK_MAXBUFFER (65536L)
+
+/*
+ * SHASM_BLOCK structure for storing block reader state.
+ * 
+ * The prototype of this structure is given in the header.
+ */
+struct SHASM_BLOCK_TAG {
+  
+  /*
+   * The status of the block reader.
+   * 
+   * This is one of the codes from shasm_error.h
+   * 
+   * If SHASM_OKAY (the initial value), then there is no error and the
+   * block reader is in a function state.  Otherwise, the block reader
+   * is in an error state and code indicates the error.
+   */
+  int code;
+  
+  /*
+   * The line number.
+   * 
+   * If the status code is SHASM_OKAY, this is the line number that the
+   * most recently read block begins at, or one if no blocks have been
+   * read yet (the initial value), or LONG_MAX if the line count has
+   * overflowed.
+   * 
+   * If the status code indicates an error state, this is the line
+   * number that the error occurred at, or LONG_MAX if the line count
+   * has overflowed.
+   */
+  long line;
+  
+  /*
+   * The capacity of the allocated buffer in bytes.
+   * 
+   * This includes space for a terminating null character.  The buffer
+   * starts out allocated at a capacity of SHASM_BLOCK_MINBUFFER, run
+   * through the shasm_block_adjcap function.  It grows by doubling as
+   * necessary, to a maximum of SHASM_BLOCK_MAXBUFFER, run through the
+   * shasm_block_adjcap function.
+   */
+  long buf_cap;
+  
+  /*
+   * The length of data stored in the buffer, in bytes.
+   * 
+   * This does not include the terminating null character.  If zero, it
+   * means the string is empty.  This starts out at zero.
+   */
+  long buf_len;
+  
+  /*
+   * Flag indicating whether a null byte has been written as data to the
+   * buffer.
+   * 
+   * The buffer will always be given a terminating null byte regardless
+   * of whether a null byte is present in the data.  However, the ptr
+   * function will check this flag to determine whether it's safe for
+   * the client to treat the string as null-terminated.
+   * 
+   * This flag starts out as zero to indicate no null byte has been
+   * written yet.
+   */
+  int null_present;
+  
+  /*
+   * Pointer to the dynamically allocated buffer.
+   * 
+   * This must be freed when the block structure is freed.  Its capacity
+   * is stored in buf_cap, the actual data length is buf_len, and
+   * null_present indicates whether the data includes a null byte.
+   * 
+   * The data always has a null termination byte following it, even if
+   * the data includes null bytes as data.
+   */
+  unsigned char *pBuf;
+  
+};
+
+/* 
+ * Local functions
+ * ===============
+ */
+
+static long shasm_block_adjcap(long v);
+
+static void shasm_block_clear(SHASM_BLOCK *pb);
+static void shasm_block_setLine(SHASM_BLOCK *pb, long line);
+static int shasm_block_addByte(SHASM_BLOCK *pb, int c);
+
+/*
+ * Adjust a capacity constant if necessary for the current platform.
+ * 
+ * The SHASM_BLOCK_MINBUFFER and SHASM_BLOCK_MAXBUFFER constants are run
+ * through this function before actually being used.
+ * 
+ * If sizeof(size_t) is four or greater, then this function simply
+ * returns the value that was passed to it as-is.
+ * 
+ * If sizeof(size_t) is two or three, then this function returns the
+ * minimum of the passed value and 65,535.
+ * 
+ * If sizeof(size_t) is less than two, a fault occurs.
+ * 
+ * This function has the effect of limiting buffer capacity to 65,535
+ * bytes on platforms with less than a 32-bit size_t value.  (It also
+ * verifies that size_t is at least 16-bit, faulting if this is not the
+ * case.)
+ * 
+ * The passed capacity value must be greater than one or a fault occurs.
+ * 
+ * Parameters:
+ * 
+ *   v - the capacity value to adjust
+ * 
+ * Return:
+ * 
+ *   the adjusted capacity value
+ */
+static long shasm_block_adjcap(long v) {
+  
+  /* Check parameter */
+  if (v <= 1) {
+    abort();
+  }
+  
+  /* Adjust if necessary depending of size_t size */
+  if ((sizeof(size_t) < 4) && (sizeof(size_t) >= 2)) {
+    /* Less than 32-bit but at least 16-bit size_t */
+    if (v > 65535L) {
+      v = 65535L;
+    }
+  } else if (sizeof(size_t) < 2) {
+    /* Less than 16-bit size_t -- not supported */
+    abort();
+  }
+  
+  /* Return value, possibly adjusted */
+  return v;
+}
 
 /* @@TODO: finish the local functions given below */
+
+/*
+ * Clear the block reader's internal buffer to an empty string.
+ * 
+ * This does not reset the error status of the block reader (see
+ * shasm_block_status).
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader to clear
+ */
+static void shasm_block_clear(SHASM_BLOCK *pb);
 
 /*
  * Set the input line number associated with the block that has just
@@ -32,18 +229,6 @@
  *   line - the line number to set
  */
 static void shasm_block_setLine(SHASM_BLOCK *pb, long line);
-
-/*
- * Clear the block reader's internal buffer to an empty string.
- * 
- * This does not reset the error status of the block reader (see
- * shasm_block_status).
- * 
- * Parameters:
- * 
- *   pb - the block reader to clear
- */
-static void shasm_block_clear(SHASM_BLOCK *pb);
 
 /*
  * Append an unsigned byte value (0-255) to the end of the block
@@ -70,3 +255,83 @@ static void shasm_block_clear(SHASM_BLOCK *pb);
  *   non-zero if successful, zero if failure
  */
 static int shasm_block_addByte(SHASM_BLOCK *pb, int c);
+
+/*
+ * Public functions
+ * ================
+ * 
+ * See the header for specifications.
+ */
+
+/*
+ * shasm_block_alloc function.
+ */
+SHASM_BLOCK *shasm_block_alloc(void) {
+  SHASM_BLOCK *pb = NULL;
+  
+  /* Allocate a block */
+  pb = (SHASM_BLOCK *) malloc(sizeof(SHASM_BLOCK));
+  if (pb == NULL) {
+    abort();
+  }
+  
+  /* Clear the block */
+  memset(pb, 0, sizeof(SHASM_BLOCK));
+  
+  /* Initialize fields */
+  pb->code = SHASM_OKAY;
+  pb->line = 1;
+  pb->buf_cap = shasm_block_adjcap(SHASM_BLOCK_MINBUFFER);
+  pb->buf_len = 0;
+  pb->null_present = 0;
+  pb->pBuf = NULL;
+  
+  /* Allocate the initial dynamic buffer */
+  pb->pBuf = (unsigned char *) malloc((size_t) pb->buf_cap);
+  if (pb->pBuf == NULL) {
+    abort();
+  }
+  
+  /* Clear the dynamic buffer to all zero */
+  memset(pb->pBuf, 0, (size_t) pb->buf_cap);
+  
+  /* Return the new block object */
+  return pb;
+}
+
+/*
+ * shasm_block_free function.
+ */
+void shasm_block_free(SHASM_BLOCK *pb) {
+  /* Free object if not NULL */
+  if (pb != NULL) {
+    /* Free dynamic buffer if not NULL */
+    if (pb->pBuf != NULL) {
+      free(pb->pBuf);
+      pb->pBuf = NULL;
+    }
+    
+    /* Free the main structure */
+    free(pb);
+  }
+}
+
+/*
+ * shasm_block_status function.
+ */
+int shasm_block_status(SHASM_BLOCK *pb, long *pLine) {
+  /* Check parameter */
+  if (pb == NULL) {
+    abort();
+  }
+  
+  /* Write line number if in error state and pLine provided */
+  if ((pb->code != SHASM_OKAY) && (pLine != NULL)) {
+    *pLine = pb->line;
+  }
+  
+  /* Return status */
+  return pb->code;
+}
+
+/* @@TODO: */

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -234,7 +234,9 @@ long shasm_block_line(SHASM_BLOCK *pb);
  * 
  * (3) If EOF is encountered, SHASM_ERR_EOF.
  * 
- * (4) If the token is longer than 65,535 bytes, SHASM_ERR_HUGEBLOCK.
+ * (4) If the token is too long to fit in the buffer, either the error
+ * SHASM_ERR_HUGEBLOCK or the error SHASM_ERR_LARGEBLOCK.  See the
+ * documentation of those errors for the difference.
  * 
  * (5) If a filtered character that is not in US-ASCII printing range
  * (0x21-0x7e) and not HT SP or LF is encountered, SHASM_ERR_TOKENCHAR,

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -9,6 +9,15 @@
  * This module converts a filtered stream of characters from shasm_input
  * into strings of zero to 65,535 bytes.
  * 
+ * On platforms where sizeof(size_t) is two bytes, this module will
+ * limit the total string size to 65,534 bytes so that the buffer
+ * capacity never goes beyond 65,535 bytes (the maximum unsigned 16-bit
+ * value), which includes space for the terminating null.  A fault will
+ * occur if this module is invoked on platforms where sizeof(size_t) is
+ * less than two bytes.  On 16-bit platforms, see in the implementation
+ * file the SHASM_BLOCK_MAXBUFFER constant, which may need to be
+ * adjusted to prevent memory faults.
+ * 
  * For multithreaded applications, this module is safe to use, provided
  * that each SHASM_BLOCK instance is only used from one thread at a 
  * time.

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -130,8 +130,8 @@ long shasm_block_count(SHASM_BLOCK *pb);
  * The client should not modify it or try to free it.  The pointer is
  * valid until another reading function is called or the block reader is
  * freed (whichever occurs first).  The client should call this function
- * again after each call to the reading function, in case the block
- * reader has reallocated the buffer.
+ * again after each call to a reading function, in case the block reader
+ * has reallocated the buffer.
  * 
  * If the length of the data is zero, then the returned pointer will
  * point to a string consisting solely of a null termination byte.

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -31,6 +31,10 @@
  * 
  * This indicates that a token or string data that decodes to a string
  * longer than 65,535 bytes was encountered in the input file.
+ * 
+ * On platforms with a size_t type less than 32-bit, the length limit is
+ * 65,534 bytes (or less, if the SHASM_BLOCK_MAXBUFFER constant has been
+ * adjusted in the block reader implementation).
  */
 #define SHASM_ERR_HUGEBLOCK (3)
 

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -30,19 +30,45 @@
  * reader's internal buffer.
  * 
  * This indicates that a token or string data that decodes to a string
- * longer than 65,535 bytes was encountered in the input file.
+ * longer than 65,535 bytes was encountered in the input file, which is
+ * against the Shastina specification.
  * 
- * On platforms with a size_t type less than 32-bit, the length limit is
- * 65,534 bytes (or less, if the SHASM_BLOCK_MAXBUFFER constant has been
- * adjusted in the block reader implementation).
+ * On platforms with a size_t less than 32 bits or where the constant
+ * SHASM_BLOCK_MAXBUFFER has been adjusted down to a lower value, this
+ * error never occurs.  Instead, SHASM_ERR_LARGEBLOCK will occur if the
+ * block size exceeds the implementation-specific lower limit on block
+ * length.
  */
 #define SHASM_ERR_HUGEBLOCK (3)
+
+/*
+ * An attempt was made to append more than the implementation-specific
+ * limit on block length to a block reader's internal buffer.
+ * 
+ * On platforms with a 32-bit size_t value and where the implementation
+ * constant SHASM_BLOCK_MAXBUFFER in the block module has not been
+ * adjusted down, this error never occurs.  Instead, SHASM_ERR_HUGEBLOCK
+ * will occur if the block size exceeds Shastina's specified maximum
+ * of 65,535 bytes.
+ * 
+ * On platforms with a size_t less than 32-bits or where the constant
+ * SHASM_BLOCK_MAXBUFFER has been adjusted to a lower value, this error
+ * occurs if a token or string data is within the 65,535-byte limit of
+ * the specification, but it exceeds an implementation-specific limit on
+ * string length that is lower than this.
+ * 
+ * The occurrence of this error indicates that although the file can't
+ * be parsed on this specific build of libshasm, there might be other
+ * builds that could potentially parse the same data without error due
+ * to a higher limit on block length.
+ */
+#define SHASM_ERR_LARGEBLOCK (4)
 
 /*
  * A character outside printing US-ASCII range appeared within a token.
  * 
  * The only characters allowed within tokens are in the range 0x21-0x7e.
  */
-#define SHASM_ERR_TOKENCHAR (4)
+#define SHASM_ERR_TOKENCHAR (5)
 
 #endif


### PR DESCRIPTION
Completed the buffer functions of the shasm_block module.  The module is now complete for this roadmap stage, except that the token function is just a placeholder.  The new source code has now been successfully compiled and a short test performed, though the token testing mode fails immediately because the token function isn't complete.  A specification divergence regarding string length has been added, and documented in the README.