### PR TITLE
Alpha - String encoding - Define interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,25 @@ The divergence, therefore, is that implementations of Shastina do not necessaril
 
 ### 2.3 Removal of implementation details
 
-Sections 5.1 and 5.2 of draft 3V:C4-5 of the Shastina Specification (and possibly other sections) include references to specific implementation details, such as specifying that the decoding map be implemented by an rtrie or suggesting that the encoding map be handled with a umap.
+In section 5.1 of draft 3V:C4-5 of the Shastina Specification, the decoding map is specified to be provided to Shastina as an rtrie structure.  However, libshasm is more flexible in interface, allowing the client to use any data structure to store the decoding map.
 
-These specifics of implementation should not appear in the specification.  Moreover, libshasm has been written so that the client can choose how to implement these structures, so libshasm is not even bound to these suggestions.
+Similarly, section 5.2 of draft 3V:C4-5 of the Shastina Specification specifies details of how the encoding table is implemented, such as that records should be in ascending order.  libshasm is once again more flexible in interface, allowing the client to use any data structure to store the encoding map.
+
+This divergence, therefore, is that libshasm isn't limited to implementing the decoding and encoding tables with the structures given in the specification.  The specification should be updated to remove these implementation-specific requirements.
 
 ### 2.4 Removal of disallow null flag
 
-Beginning in section 5 of draft 3V:C4-5 of the Shastina Specification, there are references in various sections to a "disallow null" flag, which prevents result strings from including null bytes.  In libshasm, this is handled instead by automatically tracking whether the output buffer contains null bytes or not, and whether it is therefore safe to null terminate it.
+In sections 5.2, 5.3, 5.4, 5.5, and 6.7 of draft 3V:C4-5 of the Shastina Specification, there are references to a "disallow null" flag, which prevents result strings from including null bytes.  This flag is handled as an encoding parameter in the specification.
 
-The specification should be adjusted to have the presence of null bytes be a property of the result string rather than an encoding mode.
+In libshasm, on the other hand, there is no disallow null flag.  Instead, the block reader buffer keeps track of whether a null byte has been written into it as data and therefore whether or not it is safe to null-terminate the string.
+
+The specification should be updated to remove the disallow null flag as an encoding parameter in sections 5.2-5.5, and in section 6.7 to replace the use of disallow null flag encoding parameter with a check after the string reading step to see whether the final string data includes null bytes.
+
+### 2.5 Strict output override mode
+
+libshasm adds a strict flag to be used in conjunction with the output overrides described in section 5.2 of draft 3V:C4-5 of the Shastina Specification.
+
+In the current specification, output overrides always apply to the full Unicode codepoint range of 0x0 through 0x10ffff.  libshasm behaves like the specification if the strict flag is off.  If the strict flag is on, then output overrides only apply to the full Unicode codepoint range excluding the surrogate range, which is handled by the encoding table.
 
 ## 3. Roadmap
 The current development roadmap is as follows.  Section references are to the Shastina language specification, currently on draft 3V:C4-5.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The current development roadmap is as follows.  Section references are to the Sh
 
 - [x] Input filtering chain (section 3)
 - [x] Tokenization function (section 4)
-- [ ] Normal string encoding (section 5.2)
-- [ ] Normal string decoding (section 5.1)
+- [ ] Regular string encoding (section 5.2)
+- [ ] Regular string decoding (section 5.1)
 - [ ] Base-16 special mode (section 5.3)
 - [ ] Base-85 special mode (section 5.4)
 - [ ] Numeric literals (section 6.2)
@@ -71,24 +71,24 @@ The current development roadmap is as follows.  Section references are to the Sh
 Tasks will be completed in the order shown above.  This roadmap may be revised along the way.
 
 ## 4. Current goal
-The current goal is the third stage of the roadmap, which is to complete the normal string encoding functionality of the block reader.
+The current goal is the third stage of the roadmap, which is to complete the regular string encoding functionality of the block reader.
 
-This roadmap stage makes use of the block reader architecture and testing module established in the previous roadmap stage.  This stage is closely linked with the next one, which together add a normal string data reader to the block reader module.  Since normal string data interpretation is rather complex, adding the normal string data reader is split into two separate roadmap stages.
+This roadmap stage makes use of the block reader architecture and testing module established in the previous roadmap stage.  This stage is closely linked with the next one, which together add a regular string data reader to the block reader module.  Since regular string data interpretation is rather complex, adding the regular string data reader is split into two separate roadmap stages.
 
-In this first stage of adding normal string data reading, the focus is on establishing the string encoding component, which converts decoded entity codes into the output bytes that are placed in the result string.  The next roadmap stage will then complete normal string data reading functionality by adding the string decoding component, which converts filtered input bytes into entity codes.  In short, a bottom-up model will be used to complete the normal string data reading functionality, where the module closest to output is completed first, and then the module closest to input is added on top of it.
+In this first stage of adding regular string data reading, the focus is on establishing the string encoding component, which converts decoded entity codes into the output bytes that are placed in the result string.  The next roadmap stage will then complete regular string data reading functionality by adding the string decoding component, which converts filtered input bytes into entity codes.  In short, a bottom-up model will be used to complete the regular string data reading functionality, where the module closest to output is completed first, and then the module closest to input is added on top of it.
 
 In order to be able to test the string encoding functionality, this roadmap stage will define the interface of the full string data reader function and add a placeholder for the decoding stage that ignores input and instead just sends a hardwired sequence of entity codes to the string encoding component.  This will allow the testing module to test the string encoding component as if the string decoding component already existed -- in actuality, program input will be ignored and the placeholder decoder will always provide the encoder with a fixed testing sequence of entity codes.
 
-The specific goals of this roadmap stage are therefore to extend the block reader interface with a normal string data reading function; to add a "string" mode to the test_block program, which reads normal string data from input and reports the result to standard output; to implement the string encoding component; and to define a placeholder string decoding component.
+The specific goals of this roadmap stage are therefore to extend the block reader interface with a regular string data reading function; to add a "string" mode to the test_block program, which reads regular string data from input and reports the result to standard output; to implement the string encoding component; and to define a placeholder string decoding component.
 
-In the next stage, all that must be done is to replace the string encoding component placeholder with an actual implementation.  Then normal string data reading will have been successfully added to the block reader.
+In the next stage, all that must be done is to replace the string encoding component placeholder with an actual implementation.  Then regular string data reading will have been successfully added to the block reader.
 
 Once this roadmap stage has been completed, an alpha 0.2.1 release will be made, keeping with the schedule of handling each roadmap stage that builds out the functionality of the block reader as a separate patch release of the 0.2.x series.
 
 ### 4.1 Worklist
 To reach the current goal, the following steps will be taken, in the order shown below:
 
-- [ ] Define the normal string reading interface
+- [ ] Define the regular string reading interface
 - [ ] Extend the block testing program with a string mode
 - [ ] Define a placeholder string decoder function
 - [ ] Define the string encoder, except for output overrides

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Once this roadmap stage has been completed, an alpha 0.2.1 release will be made,
 ### 4.1 Worklist
 To reach the current goal, the following steps will be taken, in the order shown below:
 
-- [ ] Define the regular string reading interface
+- [x] Define the regular string reading interface
 - [ ] Extend the block testing program with a string mode
 - [ ] Define a placeholder string decoder function
 - [ ] Define the string encoder, except for output overrides

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ If size_t is less than 32-bit but SHASM_BLOCK_MAXBUFFER has not been adjusted, t
 
 The divergence, therefore, is that implementations of Shastina do not necessarily support the full 65,535-byte string length.  An updated draft of the specification should set a minimum implementation limit and say that the actual limit is somewhere between this minimum implementation limit and 65,535.  The documentation within the libshasm sources can then be clarified.
 
+(On further thought, it might be better to leave the 65,535-byte limit as it is in the specification and drop support for environments with less than 32-bit size_t values in the libshasm implementation.  This matter will be brought up again when revising the Shastina Specification.)
+
+### 2.3 Removal of implementation details
+
+Sections 5.1 and 5.2 of draft 3V:C4-5 of the Shastina Specification (and possibly other sections) include references to specific implementation details, such as specifying that the decoding map be implemented by an rtrie or suggesting that the encoding map be handled with a umap.
+
+These specifics of implementation should not appear in the specification.  Moreover, libshasm has been written so that the client can choose how to implement these structures, so libshasm is not even bound to these suggestions.
+
 ## 3. Roadmap
 The current development roadmap is as follows.  Section references are to the Shastina language specification, currently on draft 3V:C4-5.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Sections 5.1 and 5.2 of draft 3V:C4-5 of the Shastina Specification (and possibl
 
 These specifics of implementation should not appear in the specification.  Moreover, libshasm has been written so that the client can choose how to implement these structures, so libshasm is not even bound to these suggestions.
 
+### 2.4 Removal of disallow null flag
+
+Beginning in section 5 of draft 3V:C4-5 of the Shastina Specification, there are references in various sections to a "disallow null" flag, which prevents result strings from including null bytes.  In libshasm, this is handled instead by automatically tracking whether the output buffer contains null bytes or not, and whether it is therefore safe to null terminate it.
+
+The specification should be adjusted to have the presence of null bytes be a property of the result string rather than an encoding mode.
+
 ## 3. Roadmap
 The current development roadmap is as follows.  Section references are to the Shastina language specification, currently on draft 3V:C4-5.
 

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -35,7 +35,7 @@
 #define SHASM_BLOCK_MAXSTR (65535L)
 
 /*
- * Constants for the types of normal strings.
+ * Constants for the types of regular strings.
  * 
  * This selects either "" '' or {} strings.
  */
@@ -44,7 +44,7 @@
 #define SHASM_BLOCK_STYPE_CURLY  (3)   /* {} strings */
 
 /*
- * Constants for the input override modes for normal string decoding.
+ * Constants for the input override modes for regular string decoding.
  * 
  * In "none" mode, there is no input override and everything is handled
  * by the decoding map.
@@ -62,7 +62,7 @@
 #define SHASM_BLOCK_IMODE_UTF8 (1)    /* UTF-8 input override */
 
 /*
- * Constants for the output override modes for normal string encoding.
+ * Constants for the output override modes for regular string encoding.
  * 
  * In "none" mode, there is no output override and everything is handled
  * by the encoding map.
@@ -107,7 +107,7 @@ typedef struct SHASM_BLOCK_TAG SHASM_BLOCK;
 
 /*
  * Structure for storing callback information related to the decoding
- * map used during the decoding phase of normal string data processing.
+ * map used during the decoding phase of regular string data processing.
  * 
  * It is up to the client implementation to decide what kind of data
  * structure to use to implement the decoding map.  The interface within
@@ -179,7 +179,7 @@ typedef struct {
 /*
  * Structure representing information about a numeric escape.
  * 
- * Numeric escapes are an optional feature supported during normal
+ * Numeric escapes are an optional feature supported during regular
  * string data decoding.  This feature allows the numeric value of a
  * desired entity code to be embedded within the string data as a
  * sequence of base-16 or base-10 ASCII digits.  This structure
@@ -273,7 +273,7 @@ typedef struct {
 
 /*
  * Structure for storing callback information related to numeric escapes
- * used during the decoding phase of normal string data processing.
+ * used during the decoding phase of regular string data processing.
  * 
  * This callback lets the client specify which decoded entity codes in
  * the input (if any) should be interpreted as numeric escapes, and
@@ -319,10 +319,10 @@ typedef struct {
 
 /*
  * Structure for storing callback information related to the encoding
- * map used during the encoding phase of normal string data processing.
+ * map used during the encoding phase of regular string data processing.
  * 
  * The encoding map is a key/value map where entity codes received from
- * the normal string data decoder are the key and the value is a
+ * the regular string data decoder are the key and the value is a
  * sequence of zero or more unsigned byte values (0-255) to output in
  * the resulting string.
  * 
@@ -391,10 +391,10 @@ typedef struct {
 } SHASM_BLOCK_ENCODER;
 
 /*
- * Structure for defining how normal string data is to be read.
+ * Structure for defining how regular string data is to be read.
  * 
  * This structure provides all the parameters necessary for the decoding
- * and encoding phases for normal string data.
+ * and encoding phases for regular string data.
  */
 typedef struct {
   
@@ -464,7 +464,7 @@ typedef struct {
   
   /*
    * The encoding table to use during the encoding phase of interpreting
-   * normal string data.
+   * regular string data.
    * 
    * Entity codes received from the decoder will be converted into
    * sequences of output bytes using this encoding table.  The only

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -71,4 +71,27 @@
  */
 #define SHASM_ERR_TOKENCHAR (5)
 
+/*
+ * A regular string contained a byte that couldn't be decoded.
+ */
+#define SHASM_ERR_STRINGCHAR (6)
+
+/*
+ * A numeric escape within a regular string had an improper format.
+ */
+#define SHASM_ERR_BADNUMESC (7)
+
+/*
+ * A numeric escape within a regular string selected an entity code
+ * value that is above the acceptable range for the numeric escape.
+ */
+#define SHASM_ERR_NUMESCRANGE (8)
+
+/*
+ * A numeric escape within a regular string selected an entity code in
+ * Unicode surrogate range, when this is not allowed for the particular
+ * numeric escape type.
+ */
+#define SHASM_ERR_NUMESCSUR (9)
+
 #endif


### PR DESCRIPTION
Defined the interface of the regular string reading function in the block reader header.  This interface covers both the decoding and encoding phases, although only the encoding phase will actually be implemented in this roadmap stage.  Also added some additional specification divergences to document some small changes from the draft specification.