### PR TITLE
Alpha - String encoding - String testing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Once this roadmap stage has been completed, an alpha 0.2.1 release will be made,
 To reach the current goal, the following steps will be taken, in the order shown below:
 
 - [x] Define the regular string reading interface
-- [ ] Extend the block testing program with a string mode
+- [x] Extend the block testing program with a string mode
 - [ ] Define a placeholder string decoder function
 - [ ] Define the string encoder, except for output overrides
 - [ ] Add UTF-8 and CESU-8 output overrides

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -769,3 +769,14 @@ int shasm_block_token(SHASM_BLOCK *pb, SHASM_IFLSTATE *ps) {
   /* Return status */
   return status;
 }
+
+/*
+ * shasm_block_string function.
+ */
+int shasm_block_string(
+    SHASM_BLOCK *pb,
+    SHASM_IFLSTATE *ps,
+    const SHASM_BLOCK_STRING *sp) {
+  /* @@TODO: placeholder */
+  return 0;
+}

--- a/test_block.c
+++ b/test_block.c
@@ -36,6 +36,125 @@
  * Note that this mode can't fully parse all the tokens in a normal
  * Shastina file because it does not handle interpolated string data.
  * 
+ * string
+ * ------
+ * 
+ * Regular string testing mode is invoked as follows:
+ * 
+ *   test_block string [type] [outover]
+ * 
+ * Both the [type] and [outover] parameters are required.
+ * 
+ * The [type] parameter must be either "q" "a" or "c" (case sensitive)
+ * for double-quoted strings "", apostrophe-quoted strings '', or curly
+ * bracket strings {}, respectively.
+ * 
+ * The [outover] parameter must be either "none", "utf8", "cesu8",
+ * "utf16le", "utf16be", "utf32le", or "utf32be" to select one of the
+ * output overrides or specify that no output override is in effect.  If
+ * an output override is selected, it will be in strict mode.
+ * 
+ * The program reads string data from standard input beginning
+ * immediately with the first byte.  This does not include the opening
+ * quote or curly bracket (which would come at the end of a token
+ * introducing the string data rather than being part of the string
+ * data), but it must include the closing quote or curly bracket.  Zero
+ * or more additional bytes may follow the string data.  However,
+ * nothing may precede the string data in input.
+ * 
+ * The program reports the resulting string that was read from the
+ * string data, with escapes of the form "<0a>" used for characters
+ * outside of US-ASCII printing range (0x21-0x7e).  The program also
+ * reports any additional bytes that were read after the string data,
+ * using the same escaping system for byte values outside of printing
+ * range.  If there was an error, the program reports it.
+ * 
+ * The parameters passed on the command line do not fully specify all of
+ * the details of the string type.  Some of the parameters are hardwired
+ * into the testing program.  The remainder of this testing mode
+ * documentation specifies the hardwired testing parameters.
+ * 
+ * The hardwired decoding map is as follows.  All printing US-ASCII
+ * characters (0x21-0x7e) except for backslash (0x5c), ampersand (0x26),
+ * and asterisk (0x2a) have a decoding map key consisting just of that
+ * character, mapping the character to an entity value of the same
+ * numeric value as the ASCII code.  ASCII Space (0x20) and Line Feed
+ * (0x0a) also have a decoding map key consisting just of that
+ * character, mapping the character to an entity value of the same
+ * numeric value as the ASCII code.
+ * 
+ * There are a set of decoding map keys beginning with the backslash
+ * character, representing escapes.  They are:
+ * 
+ *   \\     - literal backslash
+ *   \&     - literal ampersand
+ *   \"     - literal double quote
+ *   \'     - literal apostrophe
+ *   \{     - literal opening curly bracket
+ *   \}     - literal closing curly bracket
+ *   \n     - literal LF
+ *   \<LF>  - line continuation (see below)
+ *   \:a    - lowercase a-umlaut
+ *   \:A    - uppercase a-umlaut
+ *   \:o    - lowercase o-umlaut
+ *   \:O    - uppercase o-umlaut
+ *   \:u    - lowercase u-umlaut
+ *   \:U    - uppercase u-umlaut
+ *   \ss    - German eszett
+ *   \u#### - Unicode codepoint (see below)
+ * 
+ * The line continuation escape is a backslash as the last character of
+ * a line in the string data.  This maps to the entity code
+ * corresponding to ASCII space.  It allows for line breaks within
+ * string data that only appear as a single space in the output string.
+ * 
+ * The Unicode codepoint escape has four to six base-16 digits (####)
+ * that represent the numeric value of a Unicode codepoint, with
+ * surrogates disallowed but supplemental characters okay.  The opening
+ * "u" is case sensitive, but the base-16 digits can be either uppercase
+ * or lowercase.  This is handled as a numeric escape.
+ * 
+ * All of the other backslash escapes map to an entity code matching the
+ * Unicode/ASCII codepoint of the character they represent.
+ * 
+ * There are also a set of decoding map keys beginning with the
+ * ampersand character, representing escapes.  They are:
+ * 
+ *   &amp;  - literal ampersand
+ *   &###;  - decimal Unicode codepoint (see below)
+ *   &x###; - base-16 Unicode codepoint (see below)
+ * 
+ * The ampersand escape maps to an entity code matching the ASCII code
+ * for an ampersand character.
+ * 
+ * The decimal codepoint escape has one or more decimal digits (###)
+ * terminated with a semicolon, representing the Unicode codepoint, with
+ * surrogates disallowed but supplemental characters okay.
+ * 
+ * The base-16 codepoint escape has one or more base-16 digits (###)
+ * terminated with a semicolon, representing the Unicode codepoint, with
+ * surrogates disallowed but supplemental characters okay.
+ * 
+ * Finally, there are a set of decoding map keys beginning with the
+ * asterisk.  They are:
+ * 
+ *   **                              - literal asterisk
+ *   *                               - special key #1
+ *   *hello                          - special key #2
+ *   *helloWorld                     - special key #3
+ *   *helloEvery                     - special key #4
+ *   *helloEveryone                  - special key #5
+ *   *helloEveryoneOut               - special key #6
+ *   *helloEveryoneOutThere          - special key #7
+ *   *helloEveryoneOutThereSome      - special key #8
+ *   *helloEveryoneOutThereSomewhere - special key #9
+ * 
+ * The literal asterisk key maps to an entity matching the ASCII code
+ * for an asterisk.  Special keys 1-9 map to special entity codes
+ * outside of Unicode range.
+ * 
+ * @@TODO: remaining hardwired testing parameters
+ * 
  * @@TODO: additional testing modes
  * 
  * Compilation

--- a/test_block.c
+++ b/test_block.c
@@ -618,7 +618,7 @@ static int decmap_branch(DECMAP_STATE *pv, int c) {
  * current node has a key of length one and the lone character is an
  * asterisk, then the associated entity value is SPECIAL_KEY_1.  If the
  * current node has a key of length one and the lone character is an
- * ampersand, then the associated entity value is AMP_ESC.  Otherwise,
+ * ampersand, then the associated entity value is DEC_ESC.  Otherwise,
  * a key of length one has no associated entity code.
  * 
  * If the current node has a key of length two or greater, then a lookup
@@ -638,7 +638,130 @@ static int decmap_branch(DECMAP_STATE *pv, int c) {
  *   is no associated entity code
  */
 static long decmap_entity(DECMAP_STATE *pv) {
-  /* @@TODO: */
+  
+  long result = 0;
+  
+  /* Check parameter */
+  if (pv == NULL) {
+    abort();
+  }
+  
+  /* Decode the current key */
+  if (strlen(&(pv->key[0])) == 1) {
+    /* Key of length one -- check whether one of the special one-char
+     * keys */
+    if (pv->key[0] == '*') {
+      /* Lone asterisk key -- decode to SPECIAL_KEY_1 */
+      result = SPECIAL_KEY_1;
+    
+    } else if (pv->key[0] == '&') {
+      /* Lone ampersand key -- decode to DEC_ESC */
+      result = DEC_ESC;
+    
+    } else if (((pv->key[0] >= 0x20) && (pv->key[0] <= 0x7e)) ||
+                (pv->key[0] == 0x0a)) {
+      /* Single-char key in US-ASCII printing range, or space or line
+       * feed, and neither the asterisk nor the ampersand -- entity
+       * equals the character value of the lone character */
+      result = pv->key[0];
+    
+    } else {
+      /* Key of length one not recognized -- no entity code */
+      result = -1;
+    }
+    
+  } else {
+    /* Key not of length one -- perform lookups for all the escapes */
+    if (strcmp(pv->key, "\\\\") == 0) {
+      result = '\\';
+    
+    } else if (strcmp(pv->key, "\\&") == 0) {
+      result = '&';
+      
+    } else if (strcmp(pv->key, "\\\"") == 0) {
+      result = '"';
+    
+    } else if (strcmp(pv->key, "\\'") == 0) {
+      result = '\'';
+      
+    } else if (strcmp(pv->key, "\\{") == 0) {
+      result = '{';
+    
+    } else if (strcmp(pv->key, "\\}") == 0) {
+      result = '}';
+      
+    } else if (strcmp(pv->key, "\\n") == 0) {
+      result = '\n';
+      
+    } else if (strcmp(pv->key, "\\\n") == 0) {
+      result = ' ';
+      
+    } else if (strcmp(pv->key, "\\:a") == 0) {
+      result = 0xe4;    /* lowercase a-umlaut */
+    
+    } else if (strcmp(pv->key, "\\:A") == 0) {
+      result = 0xc4;    /* uppercase a-umlaut */
+    
+    } else if (strcmp(pv->key, "\\:o") == 0) {
+      result = 0xf6;    /* lowercase o-umlaut */
+    
+    } else if (strcmp(pv->key, "\\:O") == 0) {
+      result = 0xd6;    /* uppercase o-umlaut */
+    
+    } else if (strcmp(pv->key, "\\:u") == 0) {
+      result = 0xfc;    /* lowercase u-umlaut */
+    
+    } else if (strcmp(pv->key, "\\:U") == 0) {
+      result = 0xdc;    /* uppercase u-umlaut */
+    
+    } else if (strcmp(pv->key, "\\ss") == 0) {
+      result = 0xdf;    /* eszett */
+    
+    } else if (strcmp(pv->key, "\\u") == 0) {
+      result = U_ESC;
+    
+    } else if (strcmp(pv->key, "&amp;") == 0) {
+      result = '&';
+    
+    } else if (strcmp(pv->key, "&x") == 0) {
+      result = AMP_ESC;
+    
+    } else if (strcmp(pv->key, "**") == 0) {
+      result = '*';
+    
+    } else if (strcmp(pv->key, "*hello") == 0) {
+      result = SPECIAL_KEY_2;
+    
+    } else if (strcmp(pv->key, "*helloWorld") == 0) {
+      result = SPECIAL_KEY_3;
+    
+    } else if (strcmp(pv->key, "*helloEvery") == 0) {
+      result = SPECIAL_KEY_4;
+    
+    } else if (strcmp(pv->key, "*helloEveryone") == 0) {
+      result = SPECIAL_KEY_5;
+    
+    } else if (strcmp(pv->key, "*helloEveryoneOut") == 0) {
+      result = SPECIAL_KEY_6;
+    
+    } else if (strcmp(pv->key, "*helloEveryoneOutThere") == 0) {
+      result = SPECIAL_KEY_7;
+    
+    } else if (strcmp(pv->key, "*helloEveryoneOutThereSome") == 0) {
+      result = SPECIAL_KEY_8;
+    
+    } else if (
+        strcmp(pv->key, "*helloEveryoneOutThereSomewhere") == 0) {
+      result = SPECIAL_KEY_9;
+      
+    } else {
+      /* Unrecognized escape */
+      result = -1;
+    }
+  }
+  
+  /* Return result */
+  return result;
 }
 
 /*

--- a/test_block.c
+++ b/test_block.c
@@ -153,7 +153,25 @@
  * for an asterisk.  Special keys 1-9 map to special entity codes
  * outside of Unicode range.
  * 
- * @@TODO: remaining hardwired testing parameters
+ * The numeric escape list string format parameter is defined for the
+ * ampersand and backslash numeric escapes described above.
+ * 
+ * The encoding table is defined such that all entity codes
+ * corresponding printing to US-ASCII characters (0x21-0x7e) generate
+ * the equivalent ASCII codes, except that uppercase letters map to
+ * lowercase letters (thereby making all characters lowercase), and the
+ * tilde character is not defined (meaning it gets dropped from output).
+ * ASCII Space (0x20) and Line Feed (0x0a) are also defined, and map to
+ * their equivalent ASCII codes.  The umlaut characters and eszett
+ * character defined in the backslash escapes are defined and map to
+ * their 8-bit ISO 8859-1 values.  Finally, the special keys are defined
+ * such that they yield a sequence of :-) emoticons with the number of
+ * emoticons in the sequence equal to the number of the special key.
+ * 
+ * If a UTF-16 or UTF-32 output override is in effect, each character in
+ * the special key definitions has padding zeros added in the
+ * appropriate place to make the ASCII characters work in the desired
+ * encoding scheme.
  * 
  * @@TODO: additional testing modes
  * 

--- a/test_block.c
+++ b/test_block.c
@@ -278,9 +278,8 @@ static long enc_map(
     long buf_len);
 
 static int rawInput(void *pCustom);
+static int test_string(int stype, int omode);
 static int test_token(void);
-
-/* @@TODO: add string testing mode */
 
 /*
  * Given a long key value, a current key length, and an unsigned byte
@@ -1095,6 +1094,15 @@ static int rawInput(void *pCustom) {
 }
 
 /*
+ * @@TODO:
+ */
+static int test_string(int stype, int omode) {
+  /* @@TODO: */
+  printf("%d %d\n", stype, omode);
+  return 0;
+}
+
+/*
  * Use the block reader to read one or more tokens from standard input,
  * ending with the "|;" token.
  * 
@@ -1197,6 +1205,8 @@ static int test_token(void) {
 int main(int argc, char *argv[]) {
   
   int status = 1;
+  int stype = 0;
+  int omode = 0;
   
   /* Fail if less than one extra argument */
   if (argc < 2) {
@@ -1231,7 +1241,68 @@ int main(int argc, char *argv[]) {
           status = 0;
         }
       }
+    
+    } else if (strcmp(argv[1], "string") == 0) {
+      /* String mode -- make sure two additional parameters */
+      if (argc != 4) {
+        status = 0;
+        fprintf(stderr,
+          "Expecting two additional parameters for string mode!\n");
+      }
       
+      /* Decode string type parameter into stype */
+      if (status) {
+        if (strcmp(argv[2], "q") == 0) {
+          stype = SHASM_BLOCK_STYPE_DQUOTE;
+        
+        } else if (strcmp(argv[2], "a") == 0) {
+          stype = SHASM_BLOCK_STYPE_SQUOTE;
+          
+        } else if (strcmp(argv[2], "c") == 0) {
+          stype = SHASM_BLOCK_STYPE_CURLY;
+          
+        } else {
+          status = 0;
+          fprintf(stderr, "Unrecognized string type parameter!\n");
+        }
+      }
+      
+      /* Decode output override parameter into omode */
+      if (status) {
+        if (strcmp(argv[3], "none") == 0) {
+          omode = SHASM_BLOCK_OMODE_NONE;
+        
+        } else if (strcmp(argv[3], "utf8") == 0) {
+          omode = SHASM_BLOCK_OMODE_UTF8;
+          
+        } else if (strcmp(argv[3], "cesu8") == 0) {
+          omode = SHASM_BLOCK_OMODE_CESU8;
+        
+        } else if (strcmp(argv[3], "utf16le") == 0) {
+          omode = SHASM_BLOCK_OMODE_U16LE;
+        
+        } else if (strcmp(argv[3], "utf16be") == 0) {
+          omode = SHASM_BLOCK_OMODE_U16BE;
+        
+        } else if (strcmp(argv[3], "utf32le") == 0) {
+          omode = SHASM_BLOCK_OMODE_U32LE;
+          
+        } else if (strcmp(argv[3], "utf32be") == 0) {
+          omode = SHASM_BLOCK_OMODE_U32BE;
+          
+        } else {
+          status = 0;
+          fprintf(stderr, "Unrecognized output override parameter!\n");
+        }
+      }
+    
+      /* Invoke string mode */
+      if (status) {
+        if (!test_string(stype, omode)) {
+          status = 0;
+        }
+      }
+    
     } else {
       /* Unrecognized mode */
       status = 0;

--- a/test_block.c
+++ b/test_block.c
@@ -194,6 +194,22 @@
 /* @@TODO: additional testing modes */
 
 /*
+ * The special entity codes used in the hardwired decoding map.
+ */
+#define SPECIAL_KEY_1 (0x200001L)   /* Special keys #1-9 */
+#define SPECIAL_KEY_2 (0x200002L)
+#define SPECIAL_KEY_3 (0x200003L)
+#define SPECIAL_KEY_4 (0x200004L)
+#define SPECIAL_KEY_5 (0x200005L)
+#define SPECIAL_KEY_6 (0x200006L)
+#define SPECIAL_KEY_7 (0x200007L)
+#define SPECIAL_KEY_8 (0x200008L)
+#define SPECIAL_KEY_9 (0x200009L)
+#define DEC_ESC (0x200010L)         /* Decimal  &###; escape */
+#define AMP_ESC (0x200011L)         /* Base-16 &x###; escape */
+#define U_ESC   (0x200012L)         /* Base-16 /u#### escape */
+
+/*
  * The long asterisk keys for the decoding map.
  * 
  * This also includes the common *hello prefix
@@ -582,6 +598,47 @@ static int decmap_branch(DECMAP_STATE *pv, int c) {
   
   /* Return whether or not a branch was performed */
   return branch;
+}
+
+/*
+ * Determine the entity code associated with the current node in the
+ * decoding map, if there is such an associated entity value.
+ * 
+ * If an associated entity value is present, the return value will be
+ * the entity value, in range zero or greater.  If there is no
+ * associated entity value, the return value will be -1.
+ * 
+ * If the current node has an empty key, there is no associated entity
+ * value.
+ * 
+ * If the current node has a key of length one, then the entity value
+ * will match the value of that lone character if the lone character is
+ * in US-ASCII printing range (0x21-0x7e) plus Space (0x20) and Line
+ * Feed (0xa), but excluding backslash, ampersand, and asterisk.  If the
+ * current node has a key of length one and the lone character is an
+ * asterisk, then the associated entity value is SPECIAL_KEY_1.  If the
+ * current node has a key of length one and the lone character is an
+ * ampersand, then the associated entity value is AMP_ESC.  Otherwise,
+ * a key of length one has no associated entity code.
+ * 
+ * If the current node has a key of length two or greater, then a lookup
+ * will be made of the key value according to the escape sequences
+ * documented for the hardwired decoding map in the documentation for
+ * the "string" testing mode.  Entity codes match the specified Unicode
+ * codepoints, or one of the SPECIAL_KEY constants, or AMP_ESC, DEC_ESC,
+ * or U_ESC.
+ * 
+ * Parameters:
+ * 
+ *   pv - the decoding map structure
+ * 
+ * Return:
+ * 
+ *   the entity code associated with the current node, or -1 if there
+ *   is no associated entity code
+ */
+static long decmap_entity(DECMAP_STATE *pv) {
+  /* @@TODO: */
 }
 
 /*


### PR DESCRIPTION
Extended the block testing program (test_block) with a string mode.  Also split out function pointer definitions in the shasm_block header into typedefs to allow for easier casting of callback implementations that have a different pointer type instead of the void pointer.  Added a primitive placeholder for the string reading function so the test program compiles.

This step took longer than expected.  The decoding map and encoding table were difficult to hand compile.  Considered putting libshasm on hold to finish the umap and rtrie programs to make the table compilations automated, but decided against including external dependencies just for the testing module.