### PR TITLE
Alpha - Specification divergences - Length limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,25 @@ The line unghosting filter discards whitespace sequences consisting of SP and HT
 
 With the caveat that the tab unghosting filter may change the alignment of text in certain circumstances, the tab and line unghosting filter sequence should have the same effect as the original unghosting filter, while being much easier to implement.
 
-### 2.2 Maximum block and string length
+### 2.2 Maximum length and register limit changes
 
-Section 5.5 and a few other sections of draft 3V:C4-5 of the Shastina Specification establish a limit of 65,535 bytes as the maximum length of decoded string literals.  libshasm works according to this specification, except when the size_t is less than 32-bit or the implementation constant SHASM_BLOCK_MAXBUFFER has been adjusted in the block reader implementation.  In these cases, there is an implementation limit on strings that is lower than 65,535 bytes.
+Draft 3V:C4-5 of the Shasinta Specification has a number of limits depending on an unsigned 16-bit maximum of 65,535.  It turns out that it is much more portable and easier to implement libshasm if these limits are reduced a bit.  This section documents all the specific limit changes that libshasm makes, diverging from draft 3V:C4-5 of the specification.
 
-If size_t is less than 32-bit but SHASM_BLOCK_MAXBUFFER has not been adjusted, then this lower implementation limit on string length is 65,534 bytes, which is just one byte shy of the specification.  However, if SHASM_BLOCK_MAXBUFFER is adjusted down, this limit may be significantly lower.  libshasm distinguishes between the specification limit and the implementation limit by raising SHASM_ERR_HUGEBLOCK if the specification limit has been exceeded or SHASM_ERR_LARGEBLOCK if the implementation-specific lower limit has been exceeded -- see the documentation of those errors for further information.
+(1) In sections 5.3, 5.4, 5.5, and 6.3, change the 65,535-byte string and block limit to 32,766 bytes.  This is two bytes shy of 32 kilobytes, which allows the maximum length including a terminating null byte to be stored in a signed 16-bit value.
 
-The divergence, therefore, is that implementations of Shastina do not necessarily support the full 65,535-byte string length.  An updated draft of the specification should set a minimum implementation limit and say that the actual limit is somewhere between this minimum implementation limit and 65,535.  The documentation within the libshasm sources can then be clarified.
+(2) In section 5.5, change the example calculations to take into account the new 32,766-byte limit.
 
-(On further thought, it might be better to leave the 65,535-byte limit as it is in the specification and drop support for environments with less than 32-bit size_t values in the libshasm implementation.  This matter will be brought up again when revising the Shastina Specification.)
+(3) In section 4, add a maximum token length limit of 32,766 bytes.
+
+(4) In section 5, note that the maximum length of the final string literal is 32,766 bytes.
+
+(5) In section 5.1, note that the length limit of 32,766 bytes on the final string literal does not apply to the size of the string data on input.  All that matters is the size of the final output.
+
+(6) In section 5.2, document the maximum string literal length limit of 32,766 bytes.
+
+(7) In section 6.6, change the maximum register index to 32,767 so it can be stored in a signed 16-bit integer.
+
+(8) In section 6.7, change the maximum size of all metacommand parameter data including terminating nulls to 32,767 bytes.
 
 ### 2.3 Removal of implementation details
 

--- a/shasm_block.h
+++ b/shasm_block.h
@@ -7,16 +7,10 @@
  * Block reader module of libshasm.
  * 
  * This module converts a filtered stream of characters from shasm_input
- * into strings of zero to 65,535 bytes.
+ * into strings of zero to 32,766 bytes.
  * 
- * On platforms where sizeof(size_t) is two bytes, this module will
- * limit the total string size to 65,534 bytes so that the buffer
- * capacity never goes beyond 65,535 bytes (the maximum unsigned 16-bit
- * value), which includes space for the terminating null.  A fault will
- * occur if this module is invoked on platforms where sizeof(size_t) is
- * less than two bytes.  On 16-bit platforms, see in the implementation
- * file the SHASM_BLOCK_MAXBUFFER constant, which may need to be
- * adjusted to prevent memory faults.
+ * Undefined behavior occurs if the platform's size_t has a maximum
+ * value less than 32,767.
  * 
  * For multithreaded applications, this module is safe to use, provided
  * that each SHASM_BLOCK instance is only used from one thread at a 
@@ -37,7 +31,7 @@
  * 
  * This does not include a terminating null.
  */
-#define SHASM_BLOCK_MAXSTR (65535L)
+#define SHASM_BLOCK_MAXSTR (32766L)
 
 /*
  * Constants for the types of regular strings.
@@ -634,7 +628,7 @@ int shasm_block_status(SHASM_BLOCK *pb, long *pLine);
  * 
  * After a successful block reading function, this will be the number of
  * bytes in the result string that has been read into the buffer.  The
- * range is zero up to and including SHASM_BLOCK_MAXSTR (65,535).  This
+ * range is zero up to and including SHASM_BLOCK_MAXSTR (32,766).  This
  * does not include a terminating null character.
  * 
  * Parameters:
@@ -767,9 +761,7 @@ long shasm_block_line(SHASM_BLOCK *pb);
  * 
  * (3) If EOF is encountered, SHASM_ERR_EOF.
  * 
- * (4) If the token is too long to fit in the buffer, either the error
- * SHASM_ERR_HUGEBLOCK or the error SHASM_ERR_LARGEBLOCK.  See the
- * documentation of those errors for the difference.
+ * (4) If the token is more than 32,766 bytes, SHASM_ERR_HUGEBLOCK.
  * 
  * (5) If a filtered character that is not in US-ASCII printing range
  * (0x21-0x7e) and not HT SP or LF is encountered, SHASM_ERR_TOKENCHAR,
@@ -876,9 +868,8 @@ int shasm_block_token(SHASM_BLOCK *pb, SHASM_IFLSTATE *ps);
  * 
  * (3) If EOF is encountered, SHASM_ERR_EOF.
  * 
- * (4) If the token is too long to fit in the buffer, either the error
- * SHASM_ERR_HUGEBLOCK or the error SHASM_ERR_LARGEBLOCK.  See the
- * documentation of those errors for the difference.
+ * (4) If the result string literal is more than 32,766 bytes long,
+ * SHASM_ERR_HUGEBLOCK.
  * 
  * (5) If a filtered byte of string data can't be decoded, the error
  * SHASM_ERR_STRINGCHAR occurs.

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -26,72 +26,43 @@
 #define SHASM_ERR_EOF (2)
 
 /*
- * An attempt was made to append more than 65,535 bytes to a block
+ * An attempt was made to append more than 32,766 bytes to a block
  * reader's internal buffer.
  * 
  * This indicates that a token or string data that decodes to a string
- * longer than 65,535 bytes was encountered in the input file, which is
+ * longer than 32,766 bytes was encountered in the input file, which is
  * against the Shastina specification.
- * 
- * On platforms with a size_t less than 32 bits or where the constant
- * SHASM_BLOCK_MAXBUFFER has been adjusted down to a lower value, this
- * error never occurs.  Instead, SHASM_ERR_LARGEBLOCK will occur if the
- * block size exceeds the implementation-specific lower limit on block
- * length.
  */
 #define SHASM_ERR_HUGEBLOCK (3)
-
-/*
- * An attempt was made to append more than the implementation-specific
- * limit on block length to a block reader's internal buffer.
- * 
- * On platforms with a 32-bit size_t value and where the implementation
- * constant SHASM_BLOCK_MAXBUFFER in the block module has not been
- * adjusted down, this error never occurs.  Instead, SHASM_ERR_HUGEBLOCK
- * will occur if the block size exceeds Shastina's specified maximum
- * of 65,535 bytes.
- * 
- * On platforms with a size_t less than 32-bits or where the constant
- * SHASM_BLOCK_MAXBUFFER has been adjusted to a lower value, this error
- * occurs if a token or string data is within the 65,535-byte limit of
- * the specification, but it exceeds an implementation-specific limit on
- * string length that is lower than this.
- * 
- * The occurrence of this error indicates that although the file can't
- * be parsed on this specific build of libshasm, there might be other
- * builds that could potentially parse the same data without error due
- * to a higher limit on block length.
- */
-#define SHASM_ERR_LARGEBLOCK (4)
 
 /*
  * A character outside printing US-ASCII range appeared within a token.
  * 
  * The only characters allowed within tokens are in the range 0x21-0x7e.
  */
-#define SHASM_ERR_TOKENCHAR (5)
+#define SHASM_ERR_TOKENCHAR (4)
 
 /*
  * A regular string contained a byte that couldn't be decoded.
  */
-#define SHASM_ERR_STRINGCHAR (6)
+#define SHASM_ERR_STRINGCHAR (5)
 
 /*
  * A numeric escape within a regular string had an improper format.
  */
-#define SHASM_ERR_BADNUMESC (7)
+#define SHASM_ERR_BADNUMESC (6)
 
 /*
  * A numeric escape within a regular string selected an entity code
  * value that is above the acceptable range for the numeric escape.
  */
-#define SHASM_ERR_NUMESCRANGE (8)
+#define SHASM_ERR_NUMESCRANGE (7)
 
 /*
  * A numeric escape within a regular string selected an entity code in
  * Unicode surrogate range, when this is not allowed for the particular
  * numeric escape type.
  */
-#define SHASM_ERR_NUMESCSUR (9)
+#define SHASM_ERR_NUMESCSUR (8)
 
 #endif


### PR DESCRIPTION
Rewrote the divergence about string and block length to make it much more specific and less confusing.  Imposing a new specification limit of 32,766 bytes, and also changing the register limit to 32,767.  This makes it easier and more portable to implement, since it works even if size_t is only 16 bits.  Also rewrote the relevant source code sections to account for new limit, which makes the code simpler.