### PR TITLE
Alpha - String encoding - UTF-16 and UTF-32

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To reach the current goal, the following steps will be taken, in the order shown
 - [x] Define a placeholder string decoder function
 - [x] Define the string encoder, except for output overrides
 - [x] Add UTF-8 and CESU-8 output overrides
-- [ ] Add UTF-16 little and big endian overrides
+- [x] Add UTF-16 little and big endian overrides
 - [ ] Add UTF-32 little and big endian overrides
 
 The string mode for the testing program will read a string from standard input and report the result string to standard output, along with the rest of the input that follows the string data.  The result string is reported with escape sequences standing in for bytes outside of ASCII printing range.  Command-line parameters allow the particular output override mode to be selected, or a non-override mode using a hardwired test encoding table.  Input override mode will always be selected during testing.  A hardwired test decoding map will be used.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The current development roadmap is as follows.  Section references are to the Sh
 
 - [x] Input filtering chain (section 3)
 - [x] Tokenization function (section 4)
-- [ ] Regular string encoding (section 5.2)
+- [x] Regular string encoding (section 5.2)
 - [ ] Regular string decoding (section 5.1)
 - [ ] Base-16 special mode (section 5.3)
 - [ ] Base-85 special mode (section 5.4)
@@ -101,7 +101,7 @@ In order to be able to test the string encoding functionality, this roadmap stag
 
 The specific goals of this roadmap stage are therefore to extend the block reader interface with a regular string data reading function; to add a "string" mode to the test_block program, which reads regular string data from input and reports the result to standard output; to implement the string encoding component; and to define a placeholder string decoding component.
 
-In the next stage, all that must be done is to replace the string encoding component placeholder with an actual implementation.  Then regular string data reading will have been successfully added to the block reader.
+In the next stage, all that must be done is to replace the string decoding component placeholder with an actual implementation.  Then regular string data reading will have been successfully added to the block reader.
 
 Once this roadmap stage has been completed, an alpha 0.2.1 release will be made, keeping with the schedule of handling each roadmap stage that builds out the functionality of the block reader as a separate patch release of the 0.2.x series.
 
@@ -121,6 +121,10 @@ The string mode for the testing program will read a string from standard input a
 These steps will be performed in separate branches, with results merged back into master when complete.  At the end of this process, the block reading architecture will be established and the token reader will be done.
 
 ## 5. Releases
+
+### 0.2.1 (alpha)
+
+Began the regular string reader framework, and completed the encoding component.  The decoding component is currently just a placeholder that sends a fixed sequence of entity codes to the encoding component -- this will be replaced with the full decoder in the next release.
 
 ### 0.2.0 (alpha)
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To reach the current goal, the following steps will be taken, in the order shown
 - [x] Define the string encoder, except for output overrides
 - [x] Add UTF-8 and CESU-8 output overrides
 - [x] Add UTF-16 little and big endian overrides
-- [ ] Add UTF-32 little and big endian overrides
+- [x] Add UTF-32 little and big endian overrides
 
 The string mode for the testing program will read a string from standard input and report the result string to standard output, along with the rest of the input that follows the string data.  The result string is reported with escape sequences standing in for bytes outside of ASCII printing range.  Command-line parameters allow the particular output override mode to be selected, or a non-override mode using a hardwired test encoding table.  Input override mode will always be selected during testing.  A hardwired test decoding map will be used.
 

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -218,6 +218,7 @@ static int shasm_block_ereg(
 
 static int shasm_block_utf8(SHASM_BLOCK *pb, long entity, int cesu8);
 static int shasm_block_utf16(SHASM_BLOCK *pb, long entity, int big);
+static int shasm_block_utf32(SHASM_BLOCK *pb, long entity, int big);
 
 static int shasm_block_encode(
     SHASM_BLOCK *pb,
@@ -1033,6 +1034,110 @@ static int shasm_block_utf16(SHASM_BLOCK *pb, long entity, int big) {
 }
 
 /*
+ * Encode an entity value according to the UTF-32 encoding system and
+ * append the output bytes to the block reader buffer.
+ * 
+ * If the block reader is already in an error state when this function
+ * is called, this function fails immediately.
+ * 
+ * The given entity code must be in range zero up to and including
+ * SHASM_BLOCK_MAXCODE.  Surrogates are allowed, and will just be
+ * encoded like any other codepoint.
+ * 
+ * If big is non-zero, each UTF-32 character will be encoded in big
+ * endian order, with the most significant byte first.  If big is zero,
+ * each UTF-32 character will be encoded in little endian order, with
+ * the least significant byte first.
+ * 
+ * This function fails if the block reader buffer runs out of space.  In
+ * this case, the block reader buffer state is undefined, and only part
+ * of the output bytecode may have been written.
+ * 
+ * However, this function does *not* set an error state in the block
+ * reader.  This is the caller's responsibility.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader
+ * 
+ *   entity - the entity code to encode
+ * 
+ *   big - non-zero for big endian, zero for little endian
+ * 
+ * Return:
+ * 
+ *   non-zero if successful, zero if the block reader was already in an
+ *   error state or this function ran out of space in the block reader
+ *   buffer
+ */
+static int shasm_block_utf32(SHASM_BLOCK *pb, long entity, int big) {
+  
+  int status = 1;
+  unsigned char vb[4];
+  int c = 0;
+  
+  /* Initialize buffer */
+  memset(&(vb[0]), 0, 4);
+  
+  /* Check parameters */
+  if ((pb == NULL) || (entity < 0) || (entity > SHASM_BLOCK_MAXCODE)) {
+    abort();
+  }
+  
+  /* Fail immediately if block reader in error status */
+  if (pb->code != SHASM_OKAY) {
+    status = 0;
+  }
+  
+  /* Split entity into four bytes in vb, in little endian order */
+  if (status) {
+    vb[0] = (unsigned char) (entity & 0xff);
+    vb[1] = (unsigned char) ((entity >> 8) & 0xff);
+    vb[2] = (unsigned char) ((entity >> 16) & 0xff);
+    vb[3] = (unsigned char) ((entity >> 24) & 0xff);
+  }
+  
+  /* If in big endian order, reverse the four bytes */
+  if (status && big) {
+    c = vb[0];
+    vb[0] = vb[3];
+    vb[3] = (unsigned char) c;
+    
+    c = vb[1];
+    vb[1] = vb[2];
+    vb[2] = (unsigned char) c;
+  }
+  
+  /* Append the bytes to block reader buffer */
+  if (status) {
+    if (!shasm_block_addByte(pb, vb[0])) {
+      status = 0;
+    }
+      
+    if (status) {
+      if (!shasm_block_addByte(pb, vb[1])) {
+        status = 0;
+      }
+    }
+    
+    if (status) {
+      if (!shasm_block_addByte(pb, vb[2])) {
+        status = 0;
+      }
+    }
+    
+    if (status) {
+      if (!shasm_block_addByte(pb, vb[3])) {
+        status = 0;
+      }
+    }
+  }
+  
+  /* Return status */
+  return status;
+}
+
+/*
  * Encode an entity value using the regular string method and append the
  * output bytes to the block reader buffer.
  * 
@@ -1201,14 +1306,16 @@ static int shasm_block_encode(
       
       /* UTF-32 LE encoding */
       case SHASM_BLOCK_OMODE_U32LE:
-        /* @@TODO: */
-        abort();
+        if (!shasm_block_utf32(pb, entity, 0)) {
+          status = 0;
+        }
         break;
       
       /* UTF-32 BE encoding */
       case SHASM_BLOCK_OMODE_U32BE:
-        /* @@TODO: */
-        abort();
+        if (!shasm_block_utf32(pb, entity, 1)) {
+          status = 0;
+        }
         break;
       
       /* Unrecognized mode */

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -217,6 +217,7 @@ static int shasm_block_ereg(
     SHASM_BLOCK_TBUF *pt);
 
 static int shasm_block_utf8(SHASM_BLOCK *pb, long entity, int cesu8);
+static int shasm_block_utf16(SHASM_BLOCK *pb, long entity, int big);
 
 static int shasm_block_encode(
     SHASM_BLOCK *pb,
@@ -800,9 +801,7 @@ static int shasm_block_ereg(
  * 
  *   entity - the entity code to encode
  * 
- *   penc - the encoding table
- * 
- *   pt - an initialized temporary buffer
+ *   cesu8 - non-zero for CESU-8 mode, zero for standard UTF-8
  * 
  * Return:
  * 
@@ -917,6 +916,114 @@ static int shasm_block_utf8(SHASM_BLOCK *pb, long entity, int cesu8) {
       if (!shasm_block_addByte(pb, contb[i])) {
         status = 0;
         break;
+      }
+    }
+  }
+  
+  /* Return status */
+  return status;
+}
+
+/*
+ * Encode an entity value according to the UTF-16 encoding system and
+ * append the output bytes to the block reader buffer.
+ * 
+ * If the block reader is already in an error state when this function
+ * is called, this function fails immediately.
+ * 
+ * The given entity code must be in range zero up to and including
+ * SHASM_BLOCK_MAXCODE.  Surrogates are allowed, and will just be
+ * encoded like any other codepoint.  Supplemental characters are always
+ * encoded as surrogate pairs using shasm_block_pair.
+ * 
+ * If big is non-zero, each UTF-16 character will be encoded in big
+ * endian order, with the most significant byte first.  If big is zero,
+ * each UTF-16 character will be encoded in little endian order, with
+ * the least significant byte first.
+ * 
+ * This function fails if the block reader buffer runs out of space.  In
+ * this case, the block reader buffer state is undefined, and only part
+ * of the output bytecode may have been written.
+ * 
+ * However, this function does *not* set an error state in the block
+ * reader.  This is the caller's responsibility.
+ * 
+ * Parameters:
+ * 
+ *   pb - the block reader
+ * 
+ *   entity - the entity code to encode
+ * 
+ *   big - non-zero for big endian, zero for little endian
+ * 
+ * Return:
+ * 
+ *   non-zero if successful, zero if the block reader was already in an
+ *   error state or this function ran out of space in the block reader
+ *   buffer
+ */
+static int shasm_block_utf16(SHASM_BLOCK *pb, long entity, int big) {
+  
+  int status = 1;
+  long s1 = 0;
+  long s2 = 0;
+  unsigned char vb[2];
+  int c = 0;
+  
+  /* Initialize buffer */
+  memset(&(vb[0]), 0, 2);
+  
+  /* Check parameters */
+  if ((pb == NULL) || (entity < 0) || (entity > SHASM_BLOCK_MAXCODE)) {
+    abort();
+  }
+  
+  /* Fail immediately if block reader in error status */
+  if (pb->code != SHASM_OKAY) {
+    status = 0;
+  }
+  
+  /* If the entity code is in supplemental range, then split into a
+   * surrogate pair and recursively call this function to encode the
+   * high surrogate and then use this function call to encode the low
+   * surrogate */
+  if (status && (entity >= SHASM_BLOCK_MINSUPPLEMENTAL)) {
+    /* Split into surrogates */
+    shasm_block_pair(entity, &s1, &s2);
+
+    /* Recursively encode the high surrogate */
+    if (!shasm_block_utf16(pb, s1, big)) {
+      status = 0;
+    }
+    
+    /* Encode the low surrogate in this function call */
+    entity = s2;
+  }
+  
+  /* Entity should now be in range 0x0-0xffff -- split into two bytes in
+   * vb, in little endian order */
+  if (status) {
+    vb[0] = (unsigned char) (entity & 0xff);
+    vb[1] = (unsigned char) ((entity >> 8) & 0xff);
+  }
+  
+  /* If in big endian order, reverse the two bytes */
+  if (status && big) {
+    c = vb[0];
+    vb[0] = vb[1];
+    vb[1] = (unsigned char) c;
+  }
+  
+  
+  /* Append the bytes to block reader buffer */
+  if (status) {
+    if (!shasm_block_addByte(pb, vb[0])) {
+      status = 0;
+    }
+      
+    if (status) {
+      if (!shasm_block_addByte(pb, vb[1])) {
+        status = 0;
       }
     }
   }
@@ -1080,14 +1187,16 @@ static int shasm_block_encode(
       
       /* UTF-16 LE encoding */
       case SHASM_BLOCK_OMODE_U16LE:
-        /* @@TODO: */
-        abort();
+        if (!shasm_block_utf16(pb, entity, 0)) {
+          status = 0;
+        }
         break;
       
       /* UTF-16 BE encoding */
       case SHASM_BLOCK_OMODE_U16BE:
-        /* @@TODO: */
-        abort();
+        if (!shasm_block_utf16(pb, entity, 1)) {
+          status = 0;
+        }
         break;
       
       /* UTF-32 LE encoding */


### PR DESCRIPTION
Added the "wide character" output overrides for UTF-16 and UTF-32, thereby completing the encoding phase of the regular string data reader.