### PR TITLE
Alpha - String decoding - Interfaces - Outer decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ To reach the current goal, the following steps will be taken, in the order shown
 - [x] Define circular queue interface
 - [x] Define speculation buffer interface
 - [x] Define inner decoding interfaces
-- [ ] Revise outer decoding interface
+- [x] Revise outer decoding interface
 - [x] Write inner placeholders (return no entity)
 - [ ] Write outer function with terminal keys only
 - [ ] Add input override support to outer function

--- a/shasm_error.h
+++ b/shasm_error.h
@@ -45,7 +45,7 @@
 /*
  * A regular string contained a byte that couldn't be decoded.
  */
-#define SHASM_ERR_STRINGCHAR (5)
+#define SHASM_ERR_STRCHAR (5)
 
 /*
  * A numeric escape within a regular string had an improper format.


### PR DESCRIPTION
Revised the main regular string decoding interface.  Also, fixed a typo in shasm_error -- the error SHASM_ERR_STRINGCHAR has accidentally been changed to SHASM_ERR_STRCHAR in the other sources, so it's easier to revise the original name to STRCHAR to bring everything back into order.