### PR TITLE
Alpha - String decoding - Input override

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ To reach the current goal, the following steps will be taken, in the order shown
 - [x] Revise outer decoding interface
 - [x] Write inner placeholders (return no entity)
 - [x] Write outer function with terminal keys only
-- [ ] Add input override support to outer function
+- [x] Add input override support to outer function
 - [ ] Write outermost inner function
 - [ ] Implement circular queue
 - [ ] Implement speculation buffer

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ The outermost inner decoding function calls through to the numeric escape wrappe
 
 The outer decoding function is built around the inner decoding functions.  Unlike the inner decoding functions, it does not use the speculation buffer but rather handles everything with the pushback buffer of the input filter stack.  Its loop begins by calling the outermost inner decoding function to decode a sequence of zero or more entities (including numeric escaped entities) and send those to the encoder.  Then, it picks up where the inner decoding functions left off and tries to interpret the data using the built-in keys.  The built-in keys include the terminal (closing single or double quote or closing curly bracket) for the particular string type, and, if an input override is active, sequences of bytes with their most significant bit set.  If a terminal key is encountered, the decoder finishes.  If an input override key is encountered, the decoder decodes one or more filtered input bytes according to the input override, sending the decoded entities to the encoder.  It then loops back to the beginning.
 
+### 2.7 Input override surrogate handling
+
+In section 5.1 of draft 3V:C4-5 of the Shastina Specification, it is specified that when input override mode is active, improperly paired surrogates encoded in UTF-8 will be passed through to the encoder as-is.  In libshasm, improperly paired surrogates are not allowed during input override decoding, and their presence causes an error.
+
 ## 3. Roadmap
 The current development roadmap is as follows.  Section references are to the Shastina language specification, currently on draft 3V:C4-5.
 

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -355,6 +355,38 @@ typedef struct {
   
 } SHASM_BLOCK_SPECBUF;
 
+/*
+ * Structure for storing information related to the surrogate buffer.
+ * 
+ * Use the shasm_block_surbuf functions to manipulate this structure.
+ */
+typedef struct {
+  
+  /*
+   * The buffered surrogate, or zero if there is no buffered surrogate,
+   * or -1 if the surrogate buffer is in an error condition.
+   * 
+   * This field starts out zero, to indicate that no surrogate is
+   * buffered and there is no error.
+   * 
+   * If a low surrogate is encountered when this field has a high
+   * surrogate, then surrogates are paired to select a supplemental
+   * codepoint and this buffer is then cleared.  Encountering a low
+   * surrogate when this buffer is empty causes the buffer to go into
+   * error state since the surrogate is unpaired.
+   * 
+   * If a high surrogate is encountered when this field is empty, then
+   * it is stored in the buffer.  If a high surrogate is encountered
+   * when this field already has a high surrogate in it, then the buffer
+   * changes to error state on account of improperly paired surrogates.
+   * 
+   * At the end of input, if this buffer has a high surrogate within it,
+   * it changes to error state on account of an unpaired surrogate.
+   */
+  long buf;
+  
+} SHASM_BLOCK_SURBUF;
+
 /* 
  * Local functions
  * ===============
@@ -459,6 +491,12 @@ static long shasm_block_nomap(
     long entity,
     unsigned char *pBuf,
     long buf_len);
+
+static void shasm_block_surbuf_init(SHASM_BLOCK_SURBUF *psb);
+static long shasm_block_surbuf_process(
+    SHASM_BLOCK_SURBUF *psb,
+    long v);
+static int shasm_block_surbuf_finish(SHASM_BLOCK_SURBUF *psb);
 
 /*
  * Set a block reader into an error state.
@@ -2474,6 +2512,95 @@ static long shasm_block_nomap(
   
   /* Return zero */
   return 0;
+}
+
+/*
+ * Initialize a surrogate buffer.
+ * 
+ * This function may also be used to reset a surrogate buffer back to
+ * its initial state.  Surrogate buffers do not need to be deinitialized
+ * or cleaned up in any way before releasing.
+ * 
+ * Parameters:
+ * 
+ *   psb - the surrogate buffer
+ */
+static void shasm_block_surbuf_init(SHASM_BLOCK_SURBUF *psb) {
+  /* @@TODO: */
+}
+
+/*
+ * Process a Unicode codepoint through a surrogate buffer.
+ * 
+ * The provided codepoint v must be in range zero up to and including
+ * SHASM_BLOCK_MAXCODE.
+ * 
+ * If the surrogate buffer is already in an error state when this
+ * function is called, this function will return -1 indicating an error.
+ * 
+ * Otherwise, processing depends on whether the surrogate buffer has a
+ * high surrogate buffered or whether it is empty.
+ * 
+ * If the surrogate buffer is empty, then the function will return a
+ * non-surrogate codepoint as-is.  A high surrogate will be buffered and
+ * -2 will be returned indicating that no codepoint should be sent
+ * further yet.  A low surrogate will cause the surrogate buffer to
+ * change to error state and -1 will be returned, indicating an
+ * improperly paired surrogate.
+ * 
+ * If the surrogate buffer has a high surrogate buffered, then the
+ * function will combine a low surrogate with the high surrogate to
+ * form a supplemental codepoint, return the supplemental codepoint, and
+ * clear the buffer.  If the surrogate buffer encounters a high
+ * surrogate or a non-surrogate when a high surrogate is buffered, the
+ * surrogate buffer will transition to error state and -1 will be
+ * returned, indicating an improperly paired surrogate.
+ * 
+ * Parameters:
+ * 
+ *   psb - the surrogate buffer
+ * 
+ *   v - the codepoint to process
+ * 
+ * Return:
+ * 
+ *   a fully processed codepoint, or -1 indicating an improperly paired
+ *   surrogate, or -2 indicating that there is no fully processed
+ *   codepoint to report
+ */
+static long shasm_block_surbuf_process(
+    SHASM_BLOCK_SURBUF *psb,
+    long v) {
+  /* @@TODO: */
+}
+
+/*
+ * Verify that the surrogate buffer is in an appropriate final state.
+ * 
+ * If the surrogate buffer is in an error state, then this function
+ * returns zero indicating the surrogate buffer is not in an acceptable
+ * final state.
+ * 
+ * Otherwise, if the surrogate buffer is empty, then this function
+ * returns non-zero indicating the surrogate buffer is in an acceptable
+ * final state.  If the surrogate buffer has a high surrogate buffered,
+ * the buffer transitions to an error state and zero is returned,
+ * indicating an improperly paired surrogate.
+ * 
+ * After a successful return, the surrogate buffer will be in its
+ * initial state, and it can be reused again.
+ * 
+ * Parameters:
+ * 
+ *   psb - the surrogate buffer to check
+ * 
+ * Return:
+ * 
+ *   non-zero if surrogate buffer is in an acceptable final state, zero
+ *   if not
+ */
+static int shasm_block_surbuf_finish(SHASM_BLOCK_SURBUF *psb) {
+  /* @@TODO: */
 }
 
 /*

--- a/shasm_block.c
+++ b/shasm_block.c
@@ -498,6 +498,8 @@ static long shasm_block_surbuf_process(
     long v);
 static int shasm_block_surbuf_finish(SHASM_BLOCK_SURBUF *psb);
 
+static long shasm_block_read_utf8(SHASM_IFLSTATE *ps);
+
 /*
  * Set a block reader into an error state.
  * 
@@ -2694,6 +2696,46 @@ static int shasm_block_surbuf_finish(SHASM_BLOCK_SURBUF *psb) {
   
   /* Return status */
   return status;
+}
+
+/*
+ * Decode an extended UTF-8 codepoint from input, if possible.
+ * 
+ * This function only reads UTF-8 for codepoints in range 0x80 up to and
+ * including 0x10ffff.  It will return surrogates as-is, without pairing
+ * surrogates together to get the supplemental code points.
+ * 
+ * This function begins by reading a byte from the input filter stack.
+ * If this results in an EOF or IOERR, then the function fails on that
+ * error condition.  Otherwise, if the byte read has its most
+ * significant bit clear, the function unreads the byte and returns zero
+ * indicating that there is no extended UTF-8 codepoint to read.
+ * 
+ * If the function successfully reads a byte with its most significant
+ * bit set, then function will either successfully read a UTF-8
+ * codepoint and return it, or it will return an error.  This function
+ * checks for overlong encodings and treats them as errors.
+ * 
+ * The return value is either zero, indicating that no extended UTF-8
+ * codepoint was present to read, or a value greater than or equal to
+ * 0x80, indicating an extended UTF-8 codepoint was read, or the value
+ * SHASM_INPUT_EOF or SHASM_INPUT_IOERR if EOF or IOERR was encountered
+ * while reading, or SHASM_INPUT_INVALID if the UTF-8 code was invalid.
+ * 
+ * Parameters:
+ * 
+ *   ps - the input filter stack to read from
+ * 
+ * Return:
+ * 
+ *   zero if no extended UTF-8 present, greater than zero for an
+ *   extended UTF-8 codepoint that was read, SHASM_INPUT_EOF for EOF
+ *   encountered, SHASM_INPUT_IOERR if I/O error, or SHASM_INPUT_INVALID
+ *   if the UTF-8 was invalid
+ */
+static long shasm_block_read_utf8(SHASM_IFLSTATE *ps) {
+  /* @@TODO: */
+  abort();
 }
 
 /*


### PR DESCRIPTION
Added input override support to the outer decoding function.  The outer decoding function is now finished.  Also, added a divergence to the specification (documented in the README) to make input override surrogate handling more strict.