### PR TITLE
Alpha - String decoding - Write plan in README - Update plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ To reach the current goal, the following steps will be taken, in the order shown
 - [x] Write outermost inner function
 - [x] Implement circular queue
 - [x] Implement speculation buffer
-- [ ] Write numeric escape inner function
 - [ ] Implement decoding overlay
 - [ ] Write innermost decoding function
+- [ ] Write numeric escape inner function
 
-The basic approach is to write the interfaces first (first five steps), add placeholders (next step), and then finish the functions starting with the outermost decoding function and working inward.  At first, only empty strings (terminal key immediately) are supported.  Then, strings with only extended UTF-8 characters in input override mode are supported.  Then, strings beginning with numeric escapes.  Finally, full decoding support.
+The basic approach is to write the interfaces first (first five steps), add placeholders (next step), and then finish the functions starting with the outermost decoding function and working inward, but implement the numeric escape wrapper after the innermost function.  At first, only empty strings (terminal key immediately) are supported.  Then, strings with only extended UTF-8 characters in input override mode are supported.  Then, everything except numeric escapes.  Finally, full decoding support.
 
 These steps will be performed in separate branches, with results merged back into master when complete.  At the end of this process, the block reading architecture will be established and the token reader will be done.
 


### PR DESCRIPTION
Updated the order of the last three steps in string decoding worklist in the README.  This moves the implementation of the numeric escape function after the implementation of the innermost decoding function.  This allows the numeric escape function to be a placeholder temporarily that just passes through to the innermost decoding function, allowing that function to be tested before adding numeric escape support.